### PR TITLE
refactor(git): use system git commands instead of git2 library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["git", "commit", "ai", "openai", "gpt"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
-git2 = "0.20.0"
 clap = { version = "4.4.11", features = ["derive"] }
 reqwest = { version = "0.11.22", features = ["json", "stream"] }
 futures-util = "0.3.29"


### PR DESCRIPTION
In order to fix issue #1, we change to use system git commands instead of git2 library.